### PR TITLE
Switch controllers/services to http-errors

### DIFF
--- a/backend/src/modules/accounts/controllers/auth.controller.ts
+++ b/backend/src/modules/accounts/controllers/auth.controller.ts
@@ -10,6 +10,7 @@ import { Request, Response, NextFunction } from 'express';
 import { authService } from '@modules/accounts/services/auth.service';
 import type { OAuthProfileDTO } from '@modules/accounts/types/auth.types';
 import { clearTokenCookies, setTokenCookies } from '@modules/accounts/utils/jwt';
+import { createUnauthorized } from '@middleware/errorHandler';
 import { logger } from '@utils/logger';
 
 export class AuthController {
@@ -26,9 +27,7 @@ export class AuthController {
       const user = req.user;
 
       if (!user) {
-        const error = new Error('Not authenticated');
-        (error as unknown as { statusCode: number }).statusCode = 401;
-        return next(error);
+        return next(createUnauthorized('Not authenticated'));
       }
 
       // Return user data
@@ -47,9 +46,7 @@ export class AuthController {
       const token = req.headers.authorization?.split(' ')[1];
 
       if (!token) {
-        const error = new Error('No token provided');
-        (error as unknown as { statusCode: number }).statusCode = 401;
-        return next(error);
+        return next(createUnauthorized('No token provided'));
       }
 
       // Verify token and get user
@@ -129,9 +126,7 @@ export class AuthController {
       const refreshToken = req.cookies.refreshToken;
       
       if (!refreshToken) {
-        const error = new Error('No refresh token provided');
-        (error as unknown as { statusCode: number }).statusCode = 401;
-        return next(error);
+        return next(createUnauthorized('No refresh token provided'));
       }
       
       // Verify token and get user

--- a/backend/src/modules/accounts/controllers/kyc.controller.ts
+++ b/backend/src/modules/accounts/controllers/kyc.controller.ts
@@ -6,12 +6,11 @@ import type { AuthenticatedRequest } from '@/middleware/auth.middleware';
 import { KycService, kycService } from '@modules/accounts/services/kyc.service';
 import { KycProvider } from '@modules/accounts/types/kyc.types';
 import { KycSubmissionSchema, KycUpdateSchema } from '@modules/accounts/validators/kyc.validator';
-
-// Error interface for proper typing
-interface AppError extends Error {
-  statusCode?: number;
-  details?: Record<string, unknown>;
-}
+import {
+  createBadRequest,
+  createNotFound,
+  createUnauthorized
+} from '@middleware/errorHandler';
 
 export class KycController {
   private kycService: KycService;
@@ -35,9 +34,7 @@ export class KycController {
   ): Promise<void> => {
     try {
       if (!req.user?.id) {
-        const error: AppError = new Error('Authentication required');
-        error.statusCode = 401;
-        return next(error);
+        return next(createUnauthorized('Authentication required'));
       }
 
       const kycRecord = await this.kycService.getByUserId(req.user.id);
@@ -61,9 +58,7 @@ export class KycController {
   ): Promise<void> => {
     try {
       if (!req.user?.id) {
-        const error = new Error('Authentication required');
-        (error as AppError).statusCode = 401;
-        return next(error);
+        return next(createUnauthorized('Authentication required'));
       }
       
       const { provider } = req.params;
@@ -71,16 +66,12 @@ export class KycController {
       
       // Validate provider
       if (!Object.values(KycProvider).includes(provider as KycProvider)) {
-        const error: AppError = new Error(`Unsupported provider: ${provider}`);
-        error.statusCode = 400;
-        return next(error);
+        return next(createBadRequest(`Unsupported provider: ${provider}`));
       }
       
       // Validate redirect URL
       if (!redirectUrl || typeof redirectUrl !== 'string') {
-        const error: AppError = new Error('Invalid redirect URL');
-        error.statusCode = 400;
-        return next(error);
+        return next(createBadRequest('Invalid redirect URL'));
       }
       
       const session = await this.kycService.initiateProviderVerification(
@@ -114,17 +105,13 @@ export class KycController {
       const { userId } = req.params;
       
       if (!userId) {
-        const error: AppError = new Error('User ID is required');
-        error.statusCode = 400;
-        return next(error);
+        return next(createBadRequest('User ID is required'));
       }
       
       const kycRecord = await this.kycService.syncKycStatus(userId);
       
       if (!kycRecord) {
-        const error: AppError = new Error('KYC record not found or no provider information available');
-        error.statusCode = 404;
-        return next(error);
+        return next(createNotFound('KYC record not found or no provider information available'));
       }
       
       res.json({
@@ -156,10 +143,9 @@ export class KycController {
       // Validate request body
       const validationResult = KycSubmissionSchema.safeParse(req.body);
       if (!validationResult.success) {
-        const error: AppError = new Error('Validation error');
-        error.statusCode = 400;
-        error.details = validationResult.error.format();
-        return next(error);
+        const err = createBadRequest('Validation error');
+        (err as any).details = validationResult.error.format();
+        return next(err);
       }
 
       const kycRecord = await this.kycService.submitKyc(
@@ -208,17 +194,13 @@ export class KycController {
       const { userId } = req.params;
 
       if (!userId) {
-        const error: AppError = new Error('User ID is required');
-        error.statusCode = 400;
-        return next(error);
+        return next(createBadRequest('User ID is required'));
       }
 
       const kycRecord = await this.kycService.getByUserId(userId);
 
       if (!kycRecord) {
-        const error: AppError = new Error('KYC record not found');
-        error.statusCode = 404;
-        return next(error);
+        return next(createNotFound('KYC record not found'));
       }
 
       res.json({
@@ -242,18 +224,15 @@ export class KycController {
       const { userId } = req.params;
 
       if (!userId) {
-        const error: AppError = new Error('User ID is required');
-        error.statusCode = 400;
-        return next(error);
+        return next(createBadRequest('User ID is required'));
       }
 
       // Validate request body
       const validationResult = KycUpdateSchema.safeParse(req.body);
       if (!validationResult.success) {
-        const error: AppError = new Error('Validation error');
-        error.statusCode = 400;
-        error.details = validationResult.error.format();
-        return next(error);
+        const err = createBadRequest('Validation error');
+        (err as any).details = validationResult.error.format();
+        return next(err);
       }
 
       const kycRecord = await this.kycService.updateKycStatus(

--- a/backend/src/modules/accounts/services/auth.service.ts
+++ b/backend/src/modules/accounts/services/auth.service.ts
@@ -17,6 +17,7 @@ import { logger } from '@utils/logger';
 import { NormalizedProfileSchema } from '@modules/accounts/validators/auth.validator';
 import { createUserFromOAuthSchema } from '@modules/accounts/validators/user.validator';
 import { prisma } from '@modules/accounts/utils/prisma';
+import { createBadRequest, createInternalServerError, createNotFound } from '@middleware/errorHandler';
 
 export class AuthService {
   private prisma: PrismaClient;
@@ -43,14 +44,14 @@ export class AuthService {
       });
 
       if (!user) {
-        throw new Error('User not found');
+        throw createNotFound('User not found');
       }
 
       // Return sanitized user
       return this.sanitizeUser(user);
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     } catch (_error) {
-      throw new Error('Invalid token');
+      throw createBadRequest('Invalid token');
     }
   }
 
@@ -91,7 +92,7 @@ export class AuthService {
       const profileValidation = NormalizedProfileSchema.safeParse(normalizedProfile);
       if (!profileValidation.success) {
         logger.error('Invalid profile data', { errors: profileValidation.error.format() });
-        throw new Error('Invalid profile data');
+        throw createBadRequest('Invalid profile data');
       }
       
       // Use validated data
@@ -148,7 +149,7 @@ export class AuthService {
           const userDataValidation = createUserFromOAuthSchema.safeParse(userDataInput);
           if (!userDataValidation.success) {
             logger.error('Invalid user data for creation', { errors: userDataValidation.error.format() });
-            throw new Error('Invalid user data for creation');
+            throw createBadRequest('Invalid user data for creation');
           }
           
           // Use validated data
@@ -171,7 +172,7 @@ export class AuthService {
             error: errorMessage,
             profile: validatedProfile 
           });
-          throw new Error(`Failed to create user: ${errorMessage}`);
+          throw createInternalServerError(`Failed to create user: ${errorMessage}`);
         }
       } else {
         // Update last login timestamp

--- a/backend/src/modules/accounts/services/kyc.service.ts
+++ b/backend/src/modules/accounts/services/kyc.service.ts
@@ -3,12 +3,13 @@ import { KycRecord, PrismaClient } from '@prisma/client';
 
 // Internal modules
 import { KycStatus,
-  type KycProvider, 
-  type KycProviderSession, 
-  type KycRecordWithUser, 
-  type KycSubmissionData, 
-  type KycUpdateData 
+  type KycProvider,
+  type KycProviderSession,
+  type KycRecordWithUser,
+  type KycSubmissionData,
+  type KycUpdateData
 } from '@modules/accounts/types/kyc.types';
+import { createNotFound } from '@middleware/errorHandler';
 
 export class KycService {
   constructor(private prisma: PrismaClient) {}
@@ -37,7 +38,7 @@ export class KycService {
     });
 
     if (!user) {
-      throw new Error('User not found');
+      throw createNotFound('User not found');
     }
 
     // Create or update KYC record
@@ -72,7 +73,7 @@ export class KycService {
     });
 
     if (!existingRecord) {
-      throw new Error('KYC record not found');
+      throw createNotFound('KYC record not found');
     }
 
     // Update KYC record based on status
@@ -137,7 +138,7 @@ export class KycService {
     });
 
     if (!user) {
-      throw new Error('User not found');
+      throw createNotFound('User not found');
     }
     
     // This is a placeholder - in the actual implementation, we would call a provider service

--- a/backend/src/modules/accounts/services/user.service.ts
+++ b/backend/src/modules/accounts/services/user.service.ts
@@ -8,7 +8,7 @@ import { PrismaClient } from '@prisma/client';
 
 // Internal modules
 import { PAGINATION } from '@config/constants';
-import { AppError } from '@middleware/errorHandler';
+import { createBadRequest, createNotFound } from '@middleware/errorHandler';
 import type { 
   CreateUserDTO, 
   UpdateUserDTO, 
@@ -101,7 +101,7 @@ export class UserService {
     });
     
     if (!user) {
-      throw new AppError('User not found', 404);
+      throw createNotFound('User not found');
     }
     
     return user as UserDTO;
@@ -117,7 +117,7 @@ export class UserService {
     });
     
     if (existingUser) {
-      throw new AppError('User with this email already exists', 400);
+      throw createBadRequest('User with this email already exists');
     }
     
     // Create user
@@ -157,7 +157,7 @@ export class UserService {
     });
     
     if (!existingUser) {
-      throw new AppError('User not found', 404);
+      throw createNotFound('User not found');
     }
     
     // Check if email is being updated and is already taken
@@ -167,7 +167,7 @@ export class UserService {
       });
       
       if (emailTaken) {
-        throw new AppError('Email is already taken', 400);
+        throw createBadRequest('Email is already taken');
       }
     }
     
@@ -198,7 +198,7 @@ export class UserService {
     });
     
     if (!existingUser) {
-      throw new AppError('User not found', 404);
+      throw createNotFound('User not found');
     }
     
     // Delete user

--- a/backend/tests/unit/modules/accounts/services/auth.service.test.ts
+++ b/backend/tests/unit/modules/accounts/services/auth.service.test.ts
@@ -87,7 +87,10 @@ describe('AuthService', () => {
       mockPrisma.user.findUnique = vi.fn().mockResolvedValue(null);
 
       // Call the method and expect it to throw
-      await expect(authService.verifyToken('valid-token')).rejects.toThrow('User not found');
+      await expect(authService.verifyToken('valid-token')).rejects.toMatchObject({
+        message: 'User not found',
+        statusCode: 404
+      });
 
       // Verify the mock was called
       expect(mockPrisma.user.findUnique).toHaveBeenCalledWith({


### PR DESCRIPTION
## Summary
- refactor auth and kyc controllers to use `http-errors` helpers
- adjust services to throw `HttpError` objects
- update unit tests for new error types

## Testing
- `npm run lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_6882ab8e93048321a6381378a438f4ad